### PR TITLE
Minor changes to our osg-word-count reference implementation.

### DIFF
--- a/osg-word-count/wrapper
+++ b/osg-word-count/wrapper
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-from os.path import expanduser, basename
+from os.path import expanduser
 
 import csv
 import itertools
@@ -106,17 +106,14 @@ def download_file(ticket, src):
 
 # Download a set of files referenced in a ticket list file from iRODS, returning a list of downloaded files.
 def download_files(ticket_list_path):
-    result = []
     with TicketListReader(ticket_list_path) as tlr:
         for ticket, src in tlr:
             download_file(ticket, src)
-            result.append(basename(src))
-    return result
 
 # Run the word count job.
-def run_job(arguments, input_files, output_filename, error_filename):
+def run_job(arguments, output_filename, error_filename):
     with open(output_filename, "w") as out, open(error_filename, "w") as err:
-        rc = subprocess.call(["wc"] + arguments + input_files, stdout=out, stderr=err)
+        rc = subprocess.call(["wc"] + arguments, stdout=out, stderr=err)
         if rc != 0:
             raise Exception("wc returned exit code {0}".format(rc))
 
@@ -159,7 +156,7 @@ if __name__ == "__main__":
     # Download the files from iRODS, assuming that all tickets refer to regular files for now.
     try:
         updater.running("downloading the input files")
-        input_files = download_files(cfg.input_ticket_list)
+        download_files(cfg.input_ticket_list)
     except Exception as e:
         updater.failed("unable to download input files: {0}".format(e))
         sys.exit(1)
@@ -170,7 +167,7 @@ if __name__ == "__main__":
     # Run the job.
     try:
         updater.running("processing the input files")
-        run_job(cfg.arguments, input_files, cfg.stdout, cfg.stderr)
+        run_job(cfg.arguments, cfg.stdout, cfg.stderr)
     except Exception as e:
         updater.running("job encountered an error: {0}".format(e))
         job_failed = True

--- a/osg-word-count/wrapper
+++ b/osg-word-count/wrapper
@@ -3,7 +3,6 @@
 from __future__ import print_function
 from os.path import expanduser
 
-import csv
 import itertools
 import json
 import os
@@ -45,8 +44,8 @@ class TicketListReader:
         self.path = path
 
     def __enter__(self):
-        self.fd = open(self.path, "rb")
-        self.r = csv.reader(itertools.ifilter(lambda l: l[0] != '#', self.fd))
+        self.fd = open(self.path, "r")
+        self.r = itertools.imap(lambda l: l.strip().split(",", 1), (itertools.ifilter(lambda l: l[0] != '#', self.fd)))
         return self.r
 
     def __exit__(self, type, value, traceback):
@@ -137,11 +136,11 @@ def upload_file(ticket, irods_user, owner, src, dest):
         raise Exception("could not remove {0} permissions on {1}".format(irods_user, fullpath))
 
 # Upload a set of files to the directories referenced in a ticket list file to iRODS.
-def upload_files(ticket_list_path, owner, files):
+def upload_files(ticket_list_path, irods_user, owner, files):
     with TicketListReader(ticket_list_path) as tlr:
         for ticket, dest in tlr:
             for src in files:
-                upload_file(ticket, owner, src, dest)
+                upload_file(ticket, irods_user, owner, src, dest)
 
 if __name__ == "__main__":
     # Load the configuration file.
@@ -181,7 +180,7 @@ if __name__ == "__main__":
     # Upload the output file.
     try:
         updater.running("uploading the output files")
-        upload_files(cfg.output_ticket_list, cfg.irods_job_user, [cfg.stdout, cfg.stderr])
+        upload_files(cfg.output_ticket_list, cfg.irods_user, cfg.irods_job_user, [cfg.stdout, cfg.stderr])
     except Exception as e:
         updater.running("unable to upload output file: {0}".format(e))
         job_failed = True

--- a/osg-word-count/wrapper
+++ b/osg-word-count/wrapper
@@ -45,7 +45,7 @@ class TicketListReader:
 
     def __enter__(self):
         self.fd = open(self.path, "r")
-        self.r = itertools.imap(lambda l: l.strip().split(",", 1), (itertools.ifilter(lambda l: l[0] != '#', self.fd)))
+        self.r = itertools.imap(lambda l: l.strip().split(",", 1), itertools.ifilter(lambda l: l[0] != '#', self.fd))
         return self.r
 
     def __exit__(self, type, value, traceback):

--- a/osg-word-count/wrapper
+++ b/osg-word-count/wrapper
@@ -118,17 +118,23 @@ def run_job(arguments, output_filename, error_filename):
             raise Exception("wc returned exit code {0}".format(rc))
 
 # Upload a file or directory to iRODS.
-def upload_file(ticket, owner, src, dest):
+def upload_file(ticket, irods_user, owner, src, dest):
     rc = subprocess.call(["iput", "-rt", ticket, src, dest])
     if rc != 0:
         raise Exception("could not upload {0} to {1}".format(src, dest))
+
+    # Don't bother modifying the file permissions if the iRODS user and file owner are the same.
+    if irods_user == owner:
+        return
+
+    # Update the file permissions so that the person who submitted the job can see the output files.
     fullpath = os.path.join(dest, src)
     rc = subprocess.call(["ichmod", "own", owner, fullpath])
     if rc != 0:
         raise Exception("could not change the owner of {0} to {1}".format(fullpath, owner))
-    rc = subprocess.call(["ichmod", "null", "anonymous", fullpath])
+    rc = subprocess.call(["ichmod", "null", irods_user, fullpath])
     if rc != 0:
-        raise Exception("could not remove anonymous permissions on {0}".format(fullpath))
+        raise Exception("could not remove {0} permissions on {1}".format(irods_user, fullpath))
 
 # Upload a set of files to the directories referenced in a ticket list file to iRODS.
 def upload_files(ticket_list_path, owner, files):


### PR DESCRIPTION
- The ticket list parsing code wouldn't have worked for paths containing commas.
- The wrapper script really should accept its input arguments from the list of arguments in the config file.
- There was one reference to the anonymous user that needed to be removed.
